### PR TITLE
Add interactive dashboard cards and placeholder reports page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import LoginForm from "@/components/LoginForm";
 import DashboardLayout from "@/components/Dashboard/DashboardLayout";
 import DashboardHome from "@/components/Dashboard/DashboardHome";
 import Messages from "@/components/Dashboard/Messages";
+import Reports from "@/components/Dashboard/Reports";
 import NotFound from "./pages/NotFound";
 import { Loader2 } from "lucide-react";
 
@@ -66,6 +67,7 @@ const App = () => (
             >
               <Route index element={<DashboardHome />} />
               <Route path="messages" element={<Messages />} />
+              <Route path="reports" element={<Reports />} />
             </Route>
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/Dashboard/DashboardHome.tsx
+++ b/src/components/Dashboard/DashboardHome.tsx
@@ -1,11 +1,27 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { useAuth } from "@/contexts/AuthContext";
 import {
-  User,
+  MessageCircle,
+  FileBarChart,
   Target,
+  User,
   Building2,
+  Sparkles,
 } from "lucide-react";
 
 const getTipoInversorColor = (tipo: string) => {
@@ -23,51 +39,161 @@ const getTipoInversorColor = (tipo: string) => {
 
 const DashboardHome = () => {
   const { user } = useAuth();
+  const navigate = useNavigate();
+
+  const fullName = [user?.nombre, user?.apellido].filter(Boolean).join(" ") || "Inversionista";
+  const investorType = user?.tipoInversor || "Sin definir";
+  const brokerName = user?.broker?.nombre || user?.brokerId || "Sin asignar";
+  const objetivosContent = user?.objetivos?.trim()
+    ? user.objetivos
+    : "Comparte tus objetivos financieros con tu asesora para recibir recomendaciones personalizadas.";
+
+  const handleCardKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, path: string) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      navigate(path);
+    }
+  };
 
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Perfil de Inversor</CardTitle>
-            <Target className="h-4 w-4 text-muted-foreground" />
+    <div className="space-y-10">
+      <section className="rounded-3xl border border-border bg-gradient-to-br from-primary/10 via-primary/5 to-transparent px-6 py-8 sm:px-8">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-3">
+            <span className="inline-flex items-center gap-2 rounded-full bg-white/60 px-3 py-1 text-sm font-medium text-primary">
+              <Sparkles className="h-4 w-4" />
+              Panel principal
+            </span>
+            <div>
+              <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Hola, {fullName}</h1>
+              <p className="mt-2 max-w-2xl text-base text-muted-foreground sm:text-lg">
+                Gestiona tus comunicaciones, informes y objetivos de inversión desde un mismo lugar.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col items-start gap-3 rounded-2xl border border-border/60 bg-background/70 p-5 text-sm shadow-sm backdrop-blur sm:min-w-[220px]">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <User className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Tipo de inversor</p>
+                <Badge className={`${getTipoInversorColor(investorType)} mt-1`}>{investorType}</Badge>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <Building2 className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Bróker asignado</p>
+                <p className="text-sm font-medium text-foreground">{brokerName}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
+        <Card
+          role="button"
+          tabIndex={0}
+          onClick={() => navigate("/dashboard/messages")}
+          onKeyDown={(event) => handleCardKeyDown(event, "/dashboard/messages")}
+          className="group relative col-span-1 overflow-hidden border border-border/70 bg-card/80 transition-all duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary md:col-span-2"
+        >
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/15 via-transparent to-primary/10 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
+          <CardHeader className="relative flex flex-row items-start justify-between">
+            <div className="space-y-2">
+              <CardTitle className="text-xl font-semibold">Hablar con mi asesora</CardTitle>
+              <CardDescription>Abre el chat para mantenerte en contacto con tu asesora financiera.</CardDescription>
+            </div>
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <MessageCircle className="h-6 w-6" />
+            </div>
           </CardHeader>
-          <CardContent>
-            <Badge className={getTipoInversorColor(user?.tipoInversor || "")}>
-              {user?.tipoInversor || "Sin definir"}
-            </Badge>
+          <CardContent className="relative">
+            <p className="text-sm font-medium text-primary">Ir al chat</p>
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Bróker</CardTitle>
-            <Building2 className="h-4 w-4 text-muted-foreground" />
+        <Card
+          role="button"
+          tabIndex={0}
+          onClick={() => navigate("/dashboard/reports")}
+          onKeyDown={(event) => handleCardKeyDown(event, "/dashboard/reports")}
+          className="group relative col-span-1 overflow-hidden border border-border/70 bg-card/80 transition-all duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary md:col-span-2"
+        >
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-primary/15 via-transparent to-primary/5 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
+          <CardHeader className="relative flex flex-row items-start justify-between">
+            <div className="space-y-2">
+              <CardTitle className="text-xl font-semibold">Mis informes</CardTitle>
+              <CardDescription>Consulta los reportes y documentos que comparte tu asesora contigo.</CardDescription>
+            </div>
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <FileBarChart className="h-6 w-6" />
+            </div>
+          </CardHeader>
+          <CardContent className="relative">
+            <p className="text-sm font-medium text-primary">Ver informes</p>
+          </CardContent>
+        </Card>
+
+        <Card className="col-span-1 border border-border/70 bg-card/80 md:col-span-2">
+          <CardHeader>
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <CardTitle className="text-lg font-semibold">Mis objetivos</CardTitle>
+                <CardDescription>Revisa tus metas financieras cuando lo necesites.</CardDescription>
+              </div>
+              <Target className="h-6 w-6 text-muted-foreground" />
+            </div>
           </CardHeader>
           <CardContent>
-            <div className="text-lg font-medium">
-              {user?.broker?.nombre || user?.brokerId || "Sin asignar"}
+            <Accordion type="single" collapsible className="w-full">
+              <AccordionItem value="objetivos">
+                <AccordionTrigger className="text-left text-sm font-medium">Mostrar objetivos</AccordionTrigger>
+                <AccordionContent>
+                  <div
+                    className="prose prose-sm max-w-none text-muted-foreground"
+                    dangerouslySetInnerHTML={{ __html: objetivosContent }}
+                  />
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+          </CardContent>
+        </Card>
+
+        <Card className="col-span-1 border border-border/70 bg-card/80 md:col-span-2">
+          <CardHeader>
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <CardTitle className="text-lg font-semibold">Mi perfil</CardTitle>
+                <CardDescription>Información esencial de tu cuenta.</CardDescription>
+              </div>
+              <User className="h-6 w-6 text-muted-foreground" />
             </div>
+          </CardHeader>
+          <CardContent>
+            <dl className="space-y-4 text-sm">
+              <div className="flex items-start justify-between gap-4">
+                <dt className="text-muted-foreground">Nombre completo</dt>
+                <dd className="font-medium text-right text-foreground">{fullName}</dd>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <dt className="text-muted-foreground">Perfil de inversor</dt>
+                <dd>
+                  <Badge className={getTipoInversorColor(investorType)}>{investorType}</Badge>
+                </dd>
+              </div>
+              <div className="flex items-start justify-between gap-4">
+                <dt className="text-muted-foreground">Bróker</dt>
+                <dd className="font-medium text-right text-foreground">{brokerName}</dd>
+              </div>
+            </dl>
           </CardContent>
         </Card>
       </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Target className="h-5 w-5" />
-            Tus objetivos de inversión
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div
-            className="text-muted-foreground leading-relaxed prose prose-sm max-w-none"
-            dangerouslySetInnerHTML={{
-              __html: user?.objetivos || "Comparte tus objetivos financieros con tu asesora para recibir recomendaciones personalizadas."
-            }}
-          />
-        </CardContent>
-      </Card>
     </div>
   );
 };

--- a/src/components/Dashboard/Reports.tsx
+++ b/src/components/Dashboard/Reports.tsx
@@ -1,0 +1,36 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { FileBarChart } from "lucide-react";
+
+const Reports = () => {
+  return (
+    <div className="mt-8 space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-4">
+          <div className="rounded-full bg-primary/10 p-3 text-primary">
+            <FileBarChart className="h-6 w-6" />
+          </div>
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">Mis informes</h1>
+            <p className="text-muted-foreground">
+              Aquí encontrarás tus reportes y documentos financieros cuando estén disponibles.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <Card className="border-dashed">
+        <CardHeader>
+          <CardTitle>Próximamente</CardTitle>
+          <CardDescription>Estamos preparando esta sección para ti.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Serás notificado cuando tus informes estén disponibles para su consulta.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Reports;

--- a/src/components/Dashboard/Sidebar.tsx
+++ b/src/components/Dashboard/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { NavLink, useLocation } from "react-router-dom";
-import { Home, MessageSquare, LogOut } from "lucide-react";
+import { Home, MessageSquare, LogOut, FileBarChart } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -9,6 +9,7 @@ import { subscribeToUnreadMessagesCount } from "@/lib/firestore";
 const navigation = [
   { name: "Dashboard", href: "/dashboard", icon: Home },
   { name: "Comunicaciones", href: "/dashboard/messages", icon: MessageSquare },
+  { name: "Informes", href: "/dashboard/reports", icon: FileBarChart },
 ];
 
 const Sidebar = () => {


### PR DESCRIPTION
## Summary
- redesign the dashboard home with responsive quick-action cards for chat, reports, objectives, and profile details
- add an accordion presentation for investment objectives along with refreshed hero styling
- introduce a placeholder reports page and expose it through routing and sidebar navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54f4b6dfc8330beff67d75f6066dc