### PR TITLE
Add seen indicator for client chat messages

### DIFF
--- a/src/components/Dashboard/Messages.tsx
+++ b/src/components/Dashboard/Messages.tsx
@@ -19,6 +19,7 @@ import {
   ImageIcon,
   FileDown,
   Loader2,
+  CheckCheck,
 } from "lucide-react";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
@@ -100,8 +101,16 @@ const Messages = () => {
     }
   };
 
-  const getStatusIcon = (status: string) => {
-    switch (status) {
+  const getStatusIcon = (msg: Message) => {
+    if (msg.remitente === "cliente") {
+      if (msg.visto) {
+        return <CheckCheck className="h-3 w-3 text-green-600" />;
+      }
+
+      return <Clock className="h-3 w-3 text-yellow-600" />;
+    }
+
+    switch (msg.estado) {
       case "pendiente":
       case "enviado":
         return <Clock className="h-3 w-3 text-yellow-600" />;
@@ -218,7 +227,7 @@ const Messages = () => {
                     {renderMessageContent(msg)}
                     {msg.remitente === "cliente" && (
                       <div className="flex justify-end mt-1">
-                        {getStatusIcon(msg.estado)}
+                        {getStatusIcon(msg)}
                       </div>
                     )}
                   </div>

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -54,6 +54,7 @@ export interface Message {
   remitente: "cliente" | "asesora";
   estado: "pendiente" | "respondido" | "en_revision" | "enviado";
   leido: boolean;
+  visto: boolean;
   archivo?: Archivo;
 }
 
@@ -316,6 +317,7 @@ const mapMessageSnapshot = (
     remitente,
     estado,
     leido: Boolean(data.read),
+    visto: Boolean(data.seen ?? data.visto),
     ...(archivo ? { archivo } : {}),
   };
 };
@@ -356,6 +358,7 @@ export const sendClientMessage = async (clienteId: string, contenido: string): P
     isFromAdvisor: false,
     status: "enviado",
     read: false, // el asesor no lo leyó aún
+    seen: false,
     timestamp: serverTimestamp(),
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),


### PR DESCRIPTION
## Summary
- add the `visto` flag to chat messages fetched from Firestore and default it when sending
- render a green double check for client messages once the advisor has seen them, keeping the clock otherwise

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5562e3c748330b108668d3800fbeb