### PR TITLE
Add reports table with filters and Firestore integration

### DIFF
--- a/src/components/Dashboard/Reports.tsx
+++ b/src/components/Dashboard/Reports.tsx
@@ -1,7 +1,82 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { FileBarChart } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+import { AlertTriangle, Download, FileBarChart, Loader2 } from "lucide-react";
 
-const Reports = () => {
+import { useAuth } from "@/contexts/AuthContext";
+import { subscribeToClientReports, type Report } from "@/lib/firestore";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+const Reports: React.FC = () => {
+  const { user } = useAuth();
+  const userId = user?.id;
+
+  const [reports, setReports] = useState<Report[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [nameFilter, setNameFilter] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  useEffect(() => {
+    if (!userId) {
+      setReports([]);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    const unsubscribe = subscribeToClientReports(
+      userId,
+      (fetchedReports) => {
+        setReports(fetchedReports);
+        setIsLoading(false);
+      },
+      (firestoreError) => {
+        console.error("Error al cargar los informes", firestoreError);
+        setError("No se pudieron cargar tus informes. Intenta nuevamente más tarde.");
+        setIsLoading(false);
+      },
+    );
+
+    return () => unsubscribe();
+  }, [userId]);
+
+  const latestReport = useMemo(() => {
+    if (!reports.length) return null;
+    return [...reports].sort(
+      (a, b) => new Date(b.fecha).getTime() - new Date(a.fecha).getTime(),
+    )[0];
+  }, [reports]);
+
+  const filteredReports = useMemo(() => {
+    const normalizedName = nameFilter.trim().toLowerCase();
+    const start = startDate ? new Date(`${startDate}T00:00:00`) : null;
+    const end = endDate ? new Date(`${endDate}T23:59:59`) : null;
+
+    return reports.filter((report) => {
+      const reportDate = new Date(report.fecha);
+      const matchesName = normalizedName
+        ? report.nombre.toLowerCase().includes(normalizedName)
+        : true;
+      const matchesStart = start ? reportDate >= start : true;
+      const matchesEnd = end ? reportDate <= end : true;
+      return matchesName && matchesStart && matchesEnd;
+    });
+  }, [reports, nameFilter, startDate, endDate]);
+
+  const handleDownloadReport = (report?: Report | null) => {
+    if (!report || !report.archivo?.url) return;
+    window.open(report.archivo.url, "_blank", "noopener,noreferrer");
+  };
+
   return (
     <div className="mt-8 space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -12,21 +87,106 @@ const Reports = () => {
           <div>
             <h1 className="text-3xl font-semibold tracking-tight">Mis informes</h1>
             <p className="text-muted-foreground">
-              Aquí encontrarás tus reportes y documentos financieros cuando estén disponibles.
+              Consulta y descarga los reportes que tu asesora comparte contigo.
             </p>
           </div>
         </div>
+        <Button
+          className="w-full sm:w-auto"
+          onClick={() => handleDownloadReport(latestReport)}
+          disabled={!latestReport}
+        >
+          <Download className="mr-2 h-4 w-4" /> Descargar último informe
+        </Button>
       </div>
 
-      <Card className="border-dashed">
+      <Card>
         <CardHeader>
-          <CardTitle>Próximamente</CardTitle>
-          <CardDescription>Estamos preparando esta sección para ti.</CardDescription>
+          <CardTitle>Historial de informes</CardTitle>
+          <CardDescription>
+            Filtra por nombre o por fecha para encontrar rápidamente el documento que
+            necesitas.
+          </CardDescription>
         </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            Serás notificado cuando tus informes estén disponibles para su consulta.
-          </p>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="name-filter">Filtrar por nombre</Label>
+              <Input
+                id="name-filter"
+                placeholder="Ej. Informe mensual"
+                value={nameFilter}
+                onChange={(event) => setNameFilter(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="start-date">Desde</Label>
+              <Input
+                id="start-date"
+                type="date"
+                value={startDate}
+                max={endDate || undefined}
+                onChange={(event) => setStartDate(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="end-date">Hasta</Label>
+              <Input
+                id="end-date"
+                type="date"
+                value={endDate}
+                min={startDate || undefined}
+                onChange={(event) => setEndDate(event.target.value)}
+              />
+            </div>
+          </div>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Error al cargar</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" /> Cargando informes...
+            </div>
+          ) : filteredReports.length ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nombre</TableHead>
+                  <TableHead>Fecha</TableHead>
+                  <TableHead className="text-right">Descargar</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredReports.map((report) => (
+                  <TableRow key={report.id}>
+                    <TableCell className="font-medium">{report.nombre}</TableCell>
+                    <TableCell>
+                      {format(new Date(report.fecha), "dd 'de' MMMM 'de' yyyy", { locale: es })}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleDownloadReport(report)}
+                      >
+                        <Download className="mr-2 h-4 w-4" /> Descargar
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <div className="rounded-lg border border-dashed border-border py-10 text-center text-sm text-muted-foreground">
+              No encontramos informes con los filtros seleccionados.
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- replace the placeholder reports screen with a table that lists client reports, adds name/date filters, and a shortcut to download the latest document
- extend the Firestore adapter with a reports mapper and subscription that normalizes files stored for each client

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e555c9d57483309f3a593d19c96007