### PR TITLE
Show unread message badges in dashboard and navigation

### DIFF
--- a/src/components/Dashboard/DashboardHome.tsx
+++ b/src/components/Dashboard/DashboardHome.tsx
@@ -15,6 +15,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { useAuth } from "@/contexts/AuthContext";
+import { useUnreadMessages } from "@/contexts/UnreadMessagesContext";
 import {
   MessageCircle,
   FileBarChart,
@@ -40,6 +41,7 @@ const getTipoInversorColor = (tipo: string) => {
 const DashboardHome = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const { unreadCount } = useUnreadMessages();
 
   const fullName = [user?.nombre, user?.apellido].filter(Boolean).join(" ") || "Inversionista";
   const investorType = user?.tipoInversor || "Sin definir";
@@ -67,6 +69,11 @@ const DashboardHome = () => {
         >
           <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/15 via-transparent to-primary/10 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
           <CardHeader className="relative flex flex-row items-start justify-between">
+            {unreadCount > 0 && (
+              <Badge className="absolute right-4 top-4 min-w-[1.5rem] h-6 px-2 text-xs bg-red-500 text-white flex items-center justify-center">
+                {unreadCount}
+              </Badge>
+            )}
             <div className="space-y-2">
               <CardTitle className="text-xl font-semibold">Hablar con mi asesora</CardTitle>
               <CardDescription>Abre el chat para mantenerte en contacto con tu asesora financiera.</CardDescription>

--- a/src/components/Dashboard/DashboardLayout.tsx
+++ b/src/components/Dashboard/DashboardLayout.tsx
@@ -3,31 +3,34 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar';
 import Navbar from './NavBar';
+import { UnreadMessagesProvider } from '@/contexts/UnreadMessagesContext';
 
 const DashboardLayout = () => {
   return (
-    <div className="flex flex-col h-screen bg-background">
-      {/* Navbar superior */}
-      <header>
-        <Navbar />
-      </header>
+    <UnreadMessagesProvider>
+      <div className="flex flex-col h-screen bg-background">
+        {/* Navbar superior */}
+        <header>
+          <Navbar />
+        </header>
 
-      {/* Contenido principal */}
-      <div className="flex flex-1 overflow-hidden">
-        {/* Sidebar */}
-        <div className="fixed inset-y-0 left-0 z-10">
-          <Sidebar />
-        </div>
-
-        {/* Main */}
-        <main className="flex-1 overflow-y-auto ml-0 md:ml-64">
-          {/* Contenedor que ocupa todo el alto disponible */}
-          <div className="flex flex-col h-full min-h-0 container mx-auto px-4 sm:px-6 py-8">
-            <Outlet />
+        {/* Contenido principal */}
+        <div className="flex flex-1 overflow-hidden">
+          {/* Sidebar */}
+          <div className="fixed inset-y-0 left-0 z-10">
+            <Sidebar />
           </div>
-        </main>
+
+          {/* Main */}
+          <main className="flex-1 overflow-y-auto ml-0 md:ml-64">
+            {/* Contenedor que ocupa todo el alto disponible */}
+            <div className="flex flex-col h-full min-h-0 container mx-auto px-4 sm:px-6 py-8">
+              <Outlet />
+            </div>
+          </main>
+        </div>
       </div>
-    </div>
+    </UnreadMessagesProvider>
   );
 };
 

--- a/src/components/Dashboard/NavBar.tsx
+++ b/src/components/Dashboard/NavBar.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { TrendingUp } from 'lucide-react';
+import { MessageSquare, TrendingUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
 import { Link } from 'react-router-dom';
+import { Badge } from '@/components/ui/badge';
+import { useUnreadMessages } from '@/contexts/UnreadMessagesContext';
 
 const Navbar = () => {
   const { user, logout } = useAuth();
+  const { unreadCount } = useUnreadMessages();
 
   return (
     <nav className="bg-card border-b border-border px-4 py-3 shadow-sm z-20">
@@ -67,7 +70,27 @@ const Navbar = () => {
           </Button>
         </div>
 
-        <div className="w-10 md:hidden"></div>
+        <div className="flex items-center gap-2 md:hidden">
+          <Button
+            asChild
+            variant="ghost"
+            size="icon"
+            className="relative"
+          >
+            <Link
+              to="/dashboard/messages"
+              className="relative flex items-center justify-center"
+              aria-label="Abrir chat"
+            >
+              <MessageSquare className="h-5 w-5" />
+              {unreadCount > 0 && (
+                <Badge className="absolute -top-1.5 -right-1.5 min-w-[1.25rem] h-5 px-1.5 text-[10px] leading-none bg-red-500 text-white flex items-center justify-center">
+                  {unreadCount}
+                </Badge>
+              )}
+            </Link>
+          </Button>
+        </div>
       </div>
     </nav>
   );

--- a/src/components/Dashboard/Sidebar.tsx
+++ b/src/components/Dashboard/Sidebar.tsx
@@ -4,7 +4,7 @@ import { Home, MessageSquare, LogOut, FileBarChart } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { subscribeToUnreadMessagesCount } from "@/lib/firestore";
+import { useUnreadMessages } from "@/contexts/UnreadMessagesContext";
 
 const navigation = [
   { name: "Inicio", href: "/dashboard", icon: Home },
@@ -15,28 +15,8 @@ const navigation = [
 const Sidebar = () => {
   const location = useLocation();
   const { logout, user } = useAuth();
-  const userId = user?.id;
-
-  const [unreadCount, setUnreadCount] = useState(0);
+  const { unreadCount } = useUnreadMessages();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  useEffect(() => {
-    if (!userId) {
-      setUnreadCount(0);
-      return;
-    }
-
-    const unsubscribe = subscribeToUnreadMessagesCount(
-      userId,
-      (count) => setUnreadCount(count),
-      (error) => {
-        console.error("Error al obtener mensajes no leídos", error);
-        setUnreadCount(0);
-      },
-    );
-
-    return () => unsubscribe();
-  }, [userId]);
 
   useEffect(() => {
     const toggleMenu = () => setIsMenuOpen((prev) => !prev);

--- a/src/contexts/UnreadMessagesContext.tsx
+++ b/src/contexts/UnreadMessagesContext.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+import { subscribeToUnreadMessagesCount } from "@/lib/firestore";
+import { useAuth } from "@/contexts/AuthContext";
+
+type UnreadMessagesContextValue = {
+  unreadCount: number;
+};
+
+const UnreadMessagesContext = createContext<UnreadMessagesContextValue>({
+  unreadCount: 0,
+});
+
+export const UnreadMessagesProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { user } = useAuth();
+  const userId = user?.id;
+
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  useEffect(() => {
+    if (!userId) {
+      setUnreadCount(0);
+      return;
+    }
+
+    const unsubscribe = subscribeToUnreadMessagesCount(
+      userId,
+      (count) => {
+        setUnreadCount(count);
+      },
+      (error) => {
+        console.error("Error al obtener mensajes no leídos", error);
+        setUnreadCount(0);
+      },
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [userId]);
+
+  return (
+    <UnreadMessagesContext.Provider value={{ unreadCount }}>
+      {children}
+    </UnreadMessagesContext.Provider>
+  );
+};
+
+export const useUnreadMessages = () => useContext(UnreadMessagesContext);
+


### PR DESCRIPTION
## Summary
- centralize the unread message counter in a shared context used across dashboard components
- display unread badges on the chat card, sidebar entry, and the new mobile navbar shortcut
- add a persistent mobile chat icon that surfaces unread counts when messages arrive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e55b12680c8330bef08c4cfc1ae674