### PR TITLE
Update sidebar close control to icon

### DIFF
--- a/src/components/Dashboard/Sidebar.tsx
+++ b/src/components/Dashboard/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
-import { Home, MessageSquare, LogOut, FileBarChart } from "lucide-react";
+import { Home, MessageSquare, LogOut, FileBarChart, X } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -100,10 +100,11 @@ const Sidebar = () => {
                   ref={closeButtonRef}
                   type="button"
                   variant="ghost"
-                  className="h-8 px-3 py-1 text-sm font-medium sm:hidden"
+                  className="h-8 w-8 p-0 sm:hidden"
                   onClick={() => setIsMenuOpen(false)}
                 >
-                  Cerrar menú
+                  <X className="h-4 w-4" aria-hidden="true" />
+                  <span className="sr-only">Cerrar menú</span>
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the mobile sidebar close text with a compact X icon and maintain screen reader text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e56dfccc608330b561f17a7b0d72a1