### PR TITLE
Improve mobile spacing in dashboard layout

### DIFF
--- a/src/components/Dashboard/DashboardLayout.tsx
+++ b/src/components/Dashboard/DashboardLayout.tsx
@@ -24,7 +24,7 @@ const DashboardLayout = () => {
           {/* Main */}
           <main className="flex-1 overflow-y-auto ml-0 md:ml-64">
             {/* Contenedor que ocupa todo el alto disponible */}
-            <div className="flex flex-col h-full min-h-0 container mx-auto px-4 sm:px-6 py-8">
+            <div className="flex flex-col h-full min-h-0 w-full max-w-6xl mx-auto px-3 sm:px-6 lg:px-8 py-6 sm:py-8">
               <Outlet />
             </div>
           </main>


### PR DESCRIPTION
## Summary
- reduce horizontal and vertical padding on the dashboard content wrapper for small screens
- keep large screen readability with a centered max-width container

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e57064b1508330a1c92d71d1c2354e