### PR TITLE
Actualizar iconos de estado en mensajes del chat

### DIFF
--- a/src/components/Dashboard/Messages.tsx
+++ b/src/components/Dashboard/Messages.tsx
@@ -20,6 +20,7 @@ import {
   FileDown,
   Loader2,
   CheckCheck,
+  Check,
 } from "lucide-react";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
@@ -107,7 +108,7 @@ const Messages = () => {
         return <CheckCheck className="h-3 w-3 text-green-600" />;
       }
 
-      return <Clock className="h-3 w-3 text-yellow-600" />;
+      return <Check className="h-3 w-3 text-gray-400" />;
     }
 
     switch (msg.estado) {


### PR DESCRIPTION
## Summary
- replace the pending clock icon for client messages with a single gray check mark
- keep the double green check mark for read messages by importing the lucide `Check` icon

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e66e7ae858833095913cc0f16324da