### PR TITLE
Fix unread message indicators

### DIFF
--- a/src/components/Dashboard/DashboardHome.tsx
+++ b/src/components/Dashboard/DashboardHome.tsx
@@ -42,6 +42,8 @@ const DashboardHome = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const { unreadCount } = useUnreadMessages();
+  const hasUnreadMessages = unreadCount > 0;
+  const displayUnreadMessagesCount = unreadCount > 99 ? '99+' : `${unreadCount}`;
 
   const fullName = [user?.nombre, user?.apellido].filter(Boolean).join(" ") || "Inversionista";
   const investorType = user?.tipoInversor || "Sin definir";
@@ -69,9 +71,9 @@ const DashboardHome = () => {
         >
           <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/15 via-transparent to-primary/10 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
           <CardHeader className="relative flex flex-row items-start justify-between">
-            {unreadCount > 0 && (
+            {hasUnreadMessages && (
               <Badge className="absolute right-4 top-4 min-w-[1.5rem] h-6 px-2 text-xs bg-red-500 text-white flex items-center justify-center">
-                {unreadCount}
+                {displayUnreadMessagesCount}
               </Badge>
             )}
             <div className="space-y-2">

--- a/src/components/Dashboard/Messages.tsx
+++ b/src/components/Dashboard/Messages.tsx
@@ -49,7 +49,10 @@ const Messages = () => {
         setIsLoading(false);
 
         const unread = fetchedMessages
-          .filter((msg) => msg.remitente === "asesora" && !msg.leido)
+          .filter(
+            (msg) =>
+              msg.remitente === "asesora" && (!msg.visto || msg.estado === "pendiente" || !msg.leido),
+          )
           .map((msg) => msg.id);
 
         if (unread.length > 0) {

--- a/src/components/Dashboard/NavBar.tsx
+++ b/src/components/Dashboard/NavBar.tsx
@@ -9,6 +9,8 @@ import { useUnreadMessages } from '@/contexts/UnreadMessagesContext';
 const Navbar = () => {
   const { user, logout } = useAuth();
   const { unreadCount } = useUnreadMessages();
+  const hasUnreadMessages = unreadCount > 0;
+  const displayUnreadMessagesCount = unreadCount > 99 ? '99+' : `${unreadCount}`;
 
   return (
     <nav className="bg-card border-b border-border px-4 py-3 shadow-sm z-20">
@@ -83,9 +85,9 @@ const Navbar = () => {
               aria-label="Abrir chat"
             >
               <MessageSquare className="h-5 w-5" />
-              {unreadCount > 0 && (
+              {hasUnreadMessages && (
                 <Badge className="absolute -top-1.5 -right-1.5 min-w-[1.25rem] h-5 px-1.5 text-[10px] leading-none bg-red-500 text-white flex items-center justify-center">
-                  {unreadCount}
+                  {displayUnreadMessagesCount}
                 </Badge>
               )}
             </Link>

--- a/src/components/Dashboard/Sidebar.tsx
+++ b/src/components/Dashboard/Sidebar.tsx
@@ -17,6 +17,8 @@ const Sidebar = () => {
   const { logout, user } = useAuth();
   const { unreadCount } = useUnreadMessages();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const hasUnreadMessages = unreadCount > 0;
+  const displayUnreadMessagesCount = unreadCount > 99 ? "99+" : `${unreadCount}`;
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const originalOverflowRef = useRef<string>("");
 
@@ -129,9 +131,9 @@ const Sidebar = () => {
                     >
                       <Icon className="h-5 w-5" />
                       <span className="font-medium">{item.name}</span>
-                      {item.name === "Chat" && unreadCount > 0 && (
+                      {item.name === "Chat" && hasUnreadMessages && (
                         <Badge className="ml-auto bg-red-500 text-white text-xs px-2 min-w-5 h-5 flex items-center justify-center rounded-full">
-                          {unreadCount}
+                          {displayUnreadMessagesCount}
                         </Badge>
                       )}
                     </NavLink>

--- a/src/contexts/UnreadMessagesContext.tsx
+++ b/src/contexts/UnreadMessagesContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 
-import { subscribeToUnreadMessagesCount } from "@/lib/firestore";
+import { subscribeToClientMessages, type Message } from "@/lib/firestore";
 import { useAuth } from "@/contexts/AuthContext";
 
 type UnreadMessagesContextValue = {
@@ -24,12 +24,17 @@ export const UnreadMessagesProvider = ({
   useEffect(() => {
     if (!userId) {
       setUnreadCount(0);
-      return;
+      return undefined;
     }
 
-    const unsubscribe = subscribeToUnreadMessagesCount(
+    const unsubscribe = subscribeToClientMessages(
       userId,
-      (count) => {
+      (messages: Message[]) => {
+        const count = messages.filter(
+          (message) =>
+            message.remitente === "asesora" && (!message.visto || message.estado === "pendiente"),
+        ).length;
+
         setUnreadCount(count);
       },
       (error) => {

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -54,6 +54,7 @@ export interface Message {
   remitente: "cliente" | "asesora";
   estado: "pendiente" | "respondido" | "en_revision" | "enviado";
   leido: boolean;
+  visto: boolean;
   archivo?: Archivo;
 }
 
@@ -648,6 +649,7 @@ const mapMessageSnapshot = (
     remitente,
     estado,
     leido: Boolean(data.read),
+    visto: Boolean(data.seen ?? data.read),
     ...(archivo ? { archivo } : {}),
   };
 };
@@ -705,7 +707,7 @@ export const markMessagesAsRead = async (messageIds: string[]): Promise<void> =>
   const batch = writeBatch(db);
   messageIds.forEach((id) => {
     const ref = doc(messagesCol, id);
-    batch.update(ref, { read: true, updatedAt: serverTimestamp() });
+    batch.update(ref, { read: true, seen: true, updatedAt: serverTimestamp() });
   });
   await batch.commit();
 };


### PR DESCRIPTION
## Summary
- add message visibility tracking so Firestore mappings expose `visto` and messages marked as read also update the `seen` flag
- derive the unread counter from the message stream and reuse it across the customer sidebar, navbar, and home card with the same badge rules as the advisor panel
- ensure unread badges cap at 99+ and only render when pending advisor replies remain

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e66f2c89148330b43510f3e6b56d3a