### PR TITLE
Refresh dashboard UI with glassmorphism design

### DIFF
--- a/src/components/Dashboard/DashboardHome.tsx
+++ b/src/components/Dashboard/DashboardHome.tsx
@@ -14,6 +14,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUnreadMessages } from "@/contexts/UnreadMessagesContext";
 import { Spinner } from "@/components/ui/loading-state";
@@ -24,18 +25,21 @@ import {
   User,
   Building2,
   Sparkles,
+  CalendarCheck,
+  NotebookPen,
+  ShieldCheck,
 } from "lucide-react";
 
 const getTipoInversorColor = (tipo: string) => {
   switch (tipo) {
     case "Conservador":
-      return "bg-blue-100 text-blue-800";
+      return "bg-financial-mint/70 text-financial-navy";
     case "Moderado":
-      return "bg-yellow-100 text-yellow-800";
+      return "bg-financial-sand/80 text-foreground";
     case "Agresivo":
-      return "bg-red-100 text-red-800";
+      return "bg-financial-rose/80 text-financial-navy";
     default:
-      return "bg-gray-100 text-gray-800";
+      return "bg-white/60 text-foreground";
   }
 };
 
@@ -53,6 +57,24 @@ const DashboardHome = () => {
     ? user.objetivos
     : "Comparte tus objetivos financieros con tu asesora para recibir recomendaciones personalizadas.";
 
+  const nextSteps = [
+    {
+      title: "Agenda una revisión",
+      description: "Coordina una reunión con tu asesora para analizar tus avances del trimestre.",
+      icon: CalendarCheck,
+    },
+    {
+      title: "Actualiza tus objetivos",
+      description: "Cuéntanos si tus metas cambiaron para ajustar tus inversiones.",
+      icon: NotebookPen,
+    },
+    {
+      title: "Confirma tu perfil",
+      description: "Revisa si tu tolerancia al riesgo sigue vigente o si prefieres mayor estabilidad.",
+      icon: ShieldCheck,
+    },
+  ];
+
   const handleCardKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, path: string) => {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
@@ -61,16 +83,77 @@ const DashboardHome = () => {
   };
 
   return (
-    <div className="space-y-10">
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
+    <div className="space-y-10 pb-16">
+      <section className="relative overflow-hidden rounded-[2rem] border border-white/60 bg-gradient-to-br from-primary via-financial-blue to-financial-navy p-8 text-primary-foreground shadow-[0_55px_140px_-70px_rgba(15,23,42,0.85)]">
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute -left-24 top-10 h-64 w-64 rounded-full bg-white/10 blur-3xl" />
+          <div className="absolute right-[-3rem] top-[-3rem] h-60 w-60 rounded-full bg-white/20 blur-3xl" />
+          <div className="absolute bottom-[-4rem] left-1/3 h-48 w-48 rounded-full bg-financial-mint/40 blur-3xl" />
+        </div>
+        <div className="relative z-10 flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-xl space-y-6">
+            <Badge className="w-fit rounded-full border border-white/40 bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-white/90">
+              Bienvenida
+            </Badge>
+            <div className="space-y-3">
+              <h1 className="text-3xl font-semibold sm:text-4xl">Hola, {fullName}</h1>
+              <p className="text-base text-primary-foreground/80">
+                Tienes a tu disposición toda tu información financiera, recomendaciones personalizadas y el contacto directo con tu asesora.
+                Disfruta de una experiencia cálida y clara para tomar mejores decisiones.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Button
+                onClick={() => navigate("/dashboard/messages")}
+                className="rounded-full bg-white/90 px-5 py-2 text-sm font-semibold text-primary shadow-[0_18px_40px_-28px_rgba(15,23,42,0.65)] transition hover:bg-white"
+              >
+                Abrir chat
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => navigate("/dashboard/reports")}
+                className="rounded-full border border-white/60 bg-transparent px-5 py-2 text-sm font-semibold text-white transition hover:border-white hover:bg-white/15"
+              >
+                Ver informes
+              </Button>
+            </div>
+          </div>
+
+          <div className="grid w-full gap-4 sm:grid-cols-3 lg:w-auto">
+            <div className="rounded-3xl border border-white/30 bg-white/15 p-4 backdrop-blur-xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary-foreground/70">Perfil</p>
+              <p className="mt-2 text-lg font-semibold">{investorType}</p>
+              <p className="mt-1 text-xs text-primary-foreground/80">Tipo de inversor</p>
+            </div>
+            <div className="rounded-3xl border border-white/30 bg-white/15 p-4 backdrop-blur-xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary-foreground/70">Bróker</p>
+              <p className="mt-2 text-lg font-semibold">{brokerName}</p>
+              <p className="mt-1 text-xs text-primary-foreground/80">Entidad asignada</p>
+            </div>
+            <div className="rounded-3xl border border-white/30 bg-white/15 p-4 backdrop-blur-xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary-foreground/70">Mensajes</p>
+              <div className="mt-2 flex items-center gap-2 text-lg font-semibold">
+                {isUnreadLoading ? (
+                  <Spinner size="sm" className="text-white" />
+                ) : (
+                  <span>{hasUnreadMessages ? displayUnreadMessagesCount : "Al día"}</span>
+                )}
+              </div>
+              <p className="mt-1 text-xs text-primary-foreground/80">Estado del chat</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <Card
           role="button"
           tabIndex={0}
           onClick={() => navigate("/dashboard/messages")}
           onKeyDown={(event) => handleCardKeyDown(event, "/dashboard/messages")}
-          className="group relative col-span-1 overflow-hidden border border-border/70 bg-card/80 transition-all duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary md:col-span-2"
+          className="glass-card group relative overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         >
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/15 via-transparent to-primary/10 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-financial-mint/40 via-transparent to-financial-blue/20 opacity-0 transition duration-200 group-hover:opacity-100" />
           <CardHeader className="relative flex flex-row items-start justify-between">
             {isUnreadLoading ? (
               <span className="absolute right-4 top-4 flex h-6 w-6 items-center justify-center" aria-live="polite">
@@ -78,13 +161,15 @@ const DashboardHome = () => {
                 <span className="sr-only">Cargando mensajes no leídos</span>
               </span>
             ) : hasUnreadMessages ? (
-              <Badge className="absolute right-4 top-4 flex h-6 min-w-[1.5rem] items-center justify-center px-2 text-xs bg-red-500 text-white">
+              <Badge className="absolute right-4 top-4 flex h-6 min-w-[1.5rem] items-center justify-center rounded-full bg-financial-rose px-2 text-xs font-semibold text-financial-navy">
                 {displayUnreadMessagesCount}
               </Badge>
             ) : null}
             <div className="space-y-2">
-              <CardTitle className="text-xl font-semibold">Hablar con mi asesora</CardTitle>
-              <CardDescription>Abre el chat para mantenerte en contacto con tu asesora financiera.</CardDescription>
+              <CardTitle className="text-2xl font-semibold">Hablar con mi asesora</CardTitle>
+              <CardDescription className="max-w-md text-sm text-muted-foreground">
+                Mantente en contacto con tu asesora financiera y recibe orientación en segundos.
+              </CardDescription>
             </div>
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
               <MessageCircle className="h-6 w-6" />
@@ -100,13 +185,15 @@ const DashboardHome = () => {
           tabIndex={0}
           onClick={() => navigate("/dashboard/reports")}
           onKeyDown={(event) => handleCardKeyDown(event, "/dashboard/reports")}
-          className="group relative col-span-1 overflow-hidden border border-border/70 bg-card/80 transition-all duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary md:col-span-2"
+          className="glass-card group relative overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         >
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-primary/15 via-transparent to-primary/5 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-financial-sand/50 via-transparent to-financial-blue/15 opacity-0 transition duration-200 group-hover:opacity-100" />
           <CardHeader className="relative flex flex-row items-start justify-between">
             <div className="space-y-2">
-              <CardTitle className="text-xl font-semibold">Mis informes</CardTitle>
-              <CardDescription>Consulta los reportes y documentos que comparte tu asesora contigo.</CardDescription>
+              <CardTitle className="text-2xl font-semibold">Mis informes</CardTitle>
+              <CardDescription className="max-w-md text-sm text-muted-foreground">
+                Consulta los reportes y documentos que tu asesora comparte contigo para seguir el progreso de tus inversiones.
+              </CardDescription>
             </div>
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
               <FileBarChart className="h-6 w-6" />
@@ -116,24 +203,28 @@ const DashboardHome = () => {
             <p className="text-sm font-medium text-primary">Ver informes</p>
           </CardContent>
         </Card>
+      </section>
 
-        <Card className="col-span-1 border border-border/70 bg-card/80 md:col-span-2">
-          <CardHeader>
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <CardTitle className="text-lg font-semibold">Mis objetivos</CardTitle>
-                <CardDescription>Revisa tus metas financieras cuando lo necesites.</CardDescription>
-              </div>
-              <Target className="h-6 w-6 text-muted-foreground" />
+      <section className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Card className="glass-card">
+          <CardHeader className="flex flex-row items-start justify-between gap-4">
+            <div className="space-y-1">
+              <CardTitle className="text-lg font-semibold">Mis objetivos</CardTitle>
+              <CardDescription className="text-sm text-muted-foreground">
+                Revisa tus metas financieras cuando lo necesites.
+              </CardDescription>
             </div>
+            <Target className="h-6 w-6 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             <Accordion type="single" collapsible className="w-full">
-              <AccordionItem value="objetivos">
-                <AccordionTrigger className="text-left text-sm font-medium">Mostrar objetivos</AccordionTrigger>
-                <AccordionContent>
+              <AccordionItem value="objetivos" className="border-none">
+                <AccordionTrigger className="rounded-2xl bg-white/60 px-4 text-left text-sm font-semibold text-foreground shadow-[0_14px_45px_-30px_rgba(15,23,42,0.25)] hover:bg-white/80">
+                  Ver mis objetivos
+                </AccordionTrigger>
+                <AccordionContent className="pt-4">
                   <div
-                    className="prose prose-sm max-w-none text-muted-foreground"
+                    className="prose prose-sm max-w-none rounded-2xl bg-white/70 p-4 text-muted-foreground shadow-[0_10px_35px_-26px_rgba(15,23,42,0.25)]"
                     dangerouslySetInnerHTML={{ __html: objetivosContent }}
                   />
                 </AccordionContent>
@@ -142,15 +233,15 @@ const DashboardHome = () => {
           </CardContent>
         </Card>
 
-        <Card className="col-span-1 border border-border/70 bg-card/80 md:col-span-2">
-          <CardHeader>
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <CardTitle className="text-lg font-semibold">Mi perfil</CardTitle>
-                <CardDescription>Información esencial de tu cuenta.</CardDescription>
-              </div>
-              <User className="h-6 w-6 text-muted-foreground" />
+        <Card className="glass-card">
+          <CardHeader className="flex flex-row items-start justify-between gap-4">
+            <div className="space-y-1">
+              <CardTitle className="text-lg font-semibold">Mi perfil</CardTitle>
+              <CardDescription className="text-sm text-muted-foreground">
+                Información esencial de tu cuenta.
+              </CardDescription>
             </div>
+            <User className="h-6 w-6 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             <dl className="space-y-4 text-sm">
@@ -161,7 +252,7 @@ const DashboardHome = () => {
               <div className="flex items-start justify-between gap-4">
                 <dt className="text-muted-foreground">Perfil de inversor</dt>
                 <dd>
-                  <Badge className={getTipoInversorColor(investorType)}>{investorType}</Badge>
+                  <Badge className={`${getTipoInversorColor(investorType)} rounded-full px-3 py-1 text-xs font-semibold`}>{investorType}</Badge>
                 </dd>
               </div>
               <div className="flex items-start justify-between gap-4">
@@ -171,7 +262,64 @@ const DashboardHome = () => {
             </dl>
           </CardContent>
         </Card>
-      </div>
+
+        <Card className="glass-card">
+          <CardHeader className="flex flex-row items-start justify-between gap-4">
+            <div className="space-y-1">
+              <CardTitle className="text-lg font-semibold">Próximos pasos sugeridos</CardTitle>
+              <CardDescription className="text-sm text-muted-foreground">
+                Ideas concretas para seguir avanzando con calma.
+              </CardDescription>
+            </div>
+            <Sparkles className="h-6 w-6 text-primary" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {nextSteps.map((step) => {
+              const Icon = step.icon;
+              return (
+                <div
+                  key={step.title}
+                  className="flex items-start gap-3 rounded-2xl border border-white/40 bg-white/70 p-4 shadow-[0_12px_30px_-24px_rgba(15,23,42,0.35)]"
+                >
+                  <span className="flex h-9 w-9 items-center justify-center rounded-full bg-financial-mint/40 text-primary">
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <div className="space-y-1">
+                    <p className="font-medium text-sm text-foreground">{step.title}</p>
+                    <p className="text-sm text-muted-foreground">{step.description}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <Card className="glass-card">
+          <CardHeader className="flex flex-row items-start justify-between gap-4">
+            <div className="space-y-1">
+              <CardTitle className="text-lg font-semibold">Tu equipo de confianza</CardTitle>
+              <CardDescription className="text-sm text-muted-foreground">
+                Datos clave de tu asesora y del bróker que te acompaña día a día.
+              </CardDescription>
+            </div>
+            <Building2 className="h-6 w-6 text-muted-foreground" />
+          </CardHeader>
+          <CardContent className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-2xl border border-white/50 bg-white/70 p-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Bróker</p>
+              <p className="mt-2 text-base font-semibold text-foreground">{brokerName}</p>
+              <p className="mt-1 text-sm text-muted-foreground">Entidad que resguarda tus inversiones.</p>
+            </div>
+            <div className="rounded-2xl border border-white/50 bg-white/70 p-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Contacto</p>
+              <p className="mt-2 text-base font-semibold text-foreground">Florencia Foos</p>
+              <p className="mt-1 text-sm text-muted-foreground">Tu asesora financiera dedicada.</p>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 };

--- a/src/components/Dashboard/DashboardLayout.tsx
+++ b/src/components/Dashboard/DashboardLayout.tsx
@@ -8,23 +8,24 @@ import { UnreadMessagesProvider } from '@/contexts/UnreadMessagesContext';
 const DashboardLayout = () => {
   return (
     <UnreadMessagesProvider>
-      <div className="flex flex-col h-screen bg-background">
-        {/* Navbar superior */}
-        <header>
+      <div className="relative flex min-h-screen flex-col overflow-hidden bg-gradient-to-br from-financial-sky via-background to-white">
+        <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div className="absolute -top-32 -left-24 h-96 w-96 rounded-full bg-financial-mint/60 blur-3xl" />
+          <div className="absolute bottom-[-10rem] right-[-6rem] h-[28rem] w-[28rem] rounded-full bg-financial-blue/25 blur-3xl" />
+          <div className="absolute inset-x-1/4 top-[18%] h-64 w-[50vw] rounded-full bg-white/60 blur-[120px]" />
+        </div>
+
+        <header className="relative z-20">
           <Navbar />
         </header>
 
-        {/* Contenido principal */}
-        <div className="flex flex-1 overflow-hidden">
-          {/* Sidebar */}
-          <div className="fixed inset-y-0 left-0 z-10">
+        <div className="relative z-10 flex flex-1 overflow-hidden">
+          <div className="fixed inset-y-0 left-0 z-30">
             <Sidebar />
           </div>
 
-          {/* Main */}
-          <main className="flex-1 overflow-y-auto ml-0 md:ml-64">
-            {/* Contenedor que ocupa todo el alto disponible */}
-            <div className="flex flex-col h-full min-h-0 w-full max-w-6xl mx-auto px-3 sm:px-6 lg:px-8 sm:py-8">
+          <main className="ml-0 flex-1 overflow-y-auto pb-16 pt-4 transition-all duration-200 md:ml-64">
+            <div className="flex h-full min-h-0 w-full max-w-6xl flex-col px-4 sm:px-8 md:px-10 lg:px-12">
               <Outlet />
             </div>
           </main>

--- a/src/components/Dashboard/Messages.tsx
+++ b/src/components/Dashboard/Messages.tsx
@@ -129,19 +129,20 @@ const Messages = () => {
   );
 
   return (
-    <div className="mt-2 h-full flex flex-col overflow-hidden">
-      <div className="flex items-center gap-4 mb-4">
-        <div className="bg-primary/10 rounded-full p-3">
-          <MessageSquare className="h-6 w-6 text-primary" />
+    <div className="mt-2 flex h-full flex-col gap-6 pb-6">
+      <div className="flex items-center gap-4 rounded-3xl border border-white/60 bg-white/70 p-4 shadow-[0_20px_60px_-38px_rgba(15,23,42,0.45)]">
+        <div className="rounded-full bg-financial-mint/50 p-3 text-primary">
+          <MessageSquare className="h-5 w-5" />
         </div>
         <div>
-          <h1 className="font-bold">Chat con tu asesora</h1>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Conversa cuando quieras</p>
+          <h1 className="text-xl font-semibold text-foreground">Chat con tu asesora</h1>
         </div>
       </div>
 
-      <Card className="flex-1 flex flex-col overflow-hidden h-full">
-        <CardContent className="flex-1 flex flex-col p-0 h-full">
-          <div className="flex-1 overflow-y-auto p-4 space-y-3">
+      <Card className="glass-card flex h-full flex-1 flex-col overflow-hidden">
+        <CardContent className="flex h-full flex-1 flex-col p-0">
+          <div className="flex-1 space-y-3 overflow-y-auto p-4">
             {isLoading ? (
               <LoadingState
                 label="Cargando mensajes..."
@@ -154,13 +155,13 @@ const Messages = () => {
                   className={`max-w-[80%] ${msg.isFromAdvisor ? "mr-auto" : "ml-auto"}`}
                 >
                   <div
-                    className={`p-3 rounded-lg ${
+                    className={`rounded-2xl border px-4 py-3 shadow-[0_12px_32px_-28px_rgba(15,23,42,0.3)] ${
                       msg.isFromAdvisor
-                        ? "bg-muted border-l-4 border-border"
-                        : "bg-primary/10 border-l-4 border-primary"
+                        ? "border-white/60 bg-white/80"
+                        : "border-primary/20 bg-primary/10"
                     }`}
                   >
-                    <div className="flex items-center justify-between mb-2">
+                    <div className="mb-2 flex items-center justify-between">
                       <span className="text-sm font-medium">
                         {msg.isFromAdvisor ? "Florencia Foos" : "Tú"}
                       </span>
@@ -170,7 +171,7 @@ const Messages = () => {
                     </div>
                     {renderMessageContent(msg)}
                     {!msg.isFromAdvisor && (
-                      <div className="flex justify-end mt-1">
+                      <div className="mt-1 flex justify-end text-xs text-muted-foreground">
                         {getStatusIcon(msg)}
                       </div>
                     )}
@@ -185,8 +186,8 @@ const Messages = () => {
             <div ref={messagesEndRef} />
           </div>
 
-          <div className="border-t p-4 space-y-3 bg-background">
-            <div className="flex items-end gap-2">
+          <div className="space-y-3 border-t border-white/50 bg-white/70 p-4">
+            <div className="flex items-end gap-3">
               <Textarea
                 placeholder="Escribir nuevo mensaje..."
                 value={newMessage}
@@ -204,9 +205,10 @@ const Messages = () => {
                 onClick={handleSendMessage}
                 disabled={!newMessage.trim() || isSending || !userId}
                 size="icon"
+                className="h-10 w-10 rounded-full bg-primary text-primary-foreground shadow-[0_15px_40px_-30px_rgba(37,99,235,0.9)] hover:bg-primary/90"
               >
                 {isSending ? (
-                  <Spinner size="sm" className="text-primary" />
+                  <Spinner size="sm" className="text-primary-foreground" />
                 ) : (
                   <Send className="h-4 w-4" />
                 )}

--- a/src/components/Dashboard/NavBar.tsx
+++ b/src/components/Dashboard/NavBar.tsx
@@ -1,103 +1,134 @@
-import React from 'react';
-import { MessageSquare, TrendingUp } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { useAuth } from '@/contexts/AuthContext';
-import { Link } from 'react-router-dom';
-import { Badge } from '@/components/ui/badge';
-import { useUnreadMessages } from '@/contexts/UnreadMessagesContext';
-import { Spinner } from '@/components/ui/loading-state';
+import React from "react";
+import { MessageSquare, TrendingUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+import { Link } from "react-router-dom";
+import { Badge } from "@/components/ui/badge";
+import { useUnreadMessages } from "@/contexts/UnreadMessagesContext";
+import { Spinner } from "@/components/ui/loading-state";
 
 const Navbar = () => {
   const { user, logout } = useAuth();
   const { unreadCount, isLoading: isUnreadLoading } = useUnreadMessages();
   const hasUnreadMessages = unreadCount > 0;
-  const displayUnreadMessagesCount = unreadCount > 99 ? '99+' : `${unreadCount}`;
+  const displayUnreadMessagesCount = unreadCount > 99 ? "99+" : `${unreadCount}`;
 
   return (
-    <nav className="bg-card border-b border-border px-4 py-3 shadow-sm z-20">
-      <div className="relative flex items-center justify-between">
-        <div className="md:hidden z-10">
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={() => {
-              const event = new CustomEvent('toggle-sidebar');
-              window.dispatchEvent(event);
-            }}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 6h16M4 12h16M4 18h16"
-              />
-            </svg>
-          </Button>
+    <nav className="mx-4 mt-6 md:mx-8">
+      <div className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/70 px-4 py-4 shadow-[0_20px_60px_-38px_rgba(30,64,175,0.65)] backdrop-blur-xl">
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute -top-6 right-0 h-32 w-32 rounded-full bg-financial-blue/15 blur-2xl" />
+          <div className="absolute bottom-[-3rem] left-[20%] h-28 w-28 rounded-full bg-financial-mint/30 blur-2xl" />
         </div>
 
-        <Link
-          to="/dashboard"
-          className="absolute inset-0 flex items-center justify-center cursor-pointer"
-        >
-          <div className="flex items-center gap-3">
-            <div className="bg-primary rounded-lg p-1.5">
-              <TrendingUp className="h-5 w-5 text-primary-foreground" />
+        <div className="relative flex flex-wrap items-center justify-between gap-4">
+          <div className="flex flex-1 items-center gap-3 md:gap-4">
+            <div className="md:hidden">
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-9 w-9 rounded-full border-white/60 bg-white/70 text-foreground shadow-none"
+                onClick={() => {
+                  const event = new CustomEvent("toggle-sidebar");
+                  window.dispatchEvent(event);
+                }}
+                aria-label="Abrir menú"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
+                </svg>
+              </Button>
             </div>
-            <div className="text-center">
-              <h1 className="font-bold text-lg">EFECapital</h1>
-              <p className="text-xs text-muted-foreground">Panel Cliente</p>
+
+            <Link
+              to="/dashboard"
+              className="group flex items-center gap-3 rounded-full bg-white/70 px-3 py-2 text-sm font-semibold text-foreground shadow-[0_10px_35px_-20px_rgba(37,99,235,0.55)] transition hover:bg-white/90"
+            >
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-inner">
+                <TrendingUp className="h-4 w-4" aria-hidden="true" />
+              </span>
+              <span className="leading-tight">
+                <span className="block text-xs font-medium text-muted-foreground">Panel cliente</span>
+                EFECapital
+              </span>
+            </Link>
+          </div>
+
+          <div className="flex flex-1 items-center justify-end gap-4">
+            <div className="hidden items-center gap-3 md:flex">
+              <Button
+                asChild
+                variant="secondary"
+                className="relative rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-medium text-foreground shadow-none transition hover:border-primary/40 hover:bg-white"
+              >
+                <Link to="/dashboard/messages" className="flex items-center gap-2" aria-label="Ir al chat">
+                  <MessageSquare className="h-4 w-4 text-primary" />
+                  Mensajes
+                  {isUnreadLoading ? (
+                    <span className="flex h-5 w-5 items-center justify-center" aria-live="polite">
+                      <Spinner size="sm" className="text-primary" />
+                      <span className="sr-only">Cargando mensajes no leídos</span>
+                    </span>
+                  ) : hasUnreadMessages ? (
+                    <Badge className="ml-1 rounded-full bg-financial-rose/70 px-2 text-[11px] font-semibold text-financial-navy">
+                      {displayUnreadMessagesCount}
+                    </Badge>
+                  ) : null}
+                </Link>
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Hola, <strong className="text-foreground">{user?.nombre}</strong>
+              </span>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="rounded-full border border-transparent text-sm font-medium text-foreground/80 transition hover:border-destructive/20 hover:text-foreground"
+                onClick={() => {
+                  void logout();
+                }}
+              >
+                Cerrar sesión
+              </Button>
+            </div>
+
+            <div className="flex items-center gap-2 md:hidden">
+              <Button
+                asChild
+                variant="ghost"
+                size="icon"
+                className="relative h-9 w-9 rounded-full border border-white/60 bg-white/80 text-foreground shadow-none"
+              >
+                <Link
+                  to="/dashboard/messages"
+                  className="relative flex items-center justify-center"
+                  aria-label="Abrir chat"
+                >
+                  <MessageSquare className="h-4 w-4" />
+                  {isUnreadLoading ? (
+                    <span className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center" aria-live="polite">
+                      <Spinner size="sm" className="text-primary" />
+                      <span className="sr-only">Cargando mensajes no leídos</span>
+                    </span>
+                  ) : hasUnreadMessages ? (
+                    <Badge className="absolute -top-1.5 -right-1.5 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-financial-rose px-1.5 text-[10px] leading-none text-financial-navy">
+                      {displayUnreadMessagesCount}
+                    </Badge>
+                  ) : null}
+                </Link>
+              </Button>
             </div>
           </div>
-        </Link>
-
-        <div className="hidden md:flex items-center gap-4 mr-2">
-          <span className="text-sm text-foreground">
-            Hola, <strong>{user?.nombre}</strong>
-          </span>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => {
-              void logout();
-            }}
-            className="text-foreground/70 hover:text-foreground"
-          >
-            Cerrar sesión
-          </Button>
-        </div>
-
-        <div className="flex items-center gap-2 md:hidden">
-          <Button
-            asChild
-            variant="ghost"
-            size="icon"
-            className="relative"
-          >
-            <Link
-              to="/dashboard/messages"
-              className="relative flex items-center justify-center"
-              aria-label="Abrir chat"
-            >
-              <MessageSquare className="h-5 w-5" />
-              {isUnreadLoading ? (
-                <span className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center" aria-live="polite">
-                  <Spinner size="sm" className="text-primary" />
-                  <span className="sr-only">Cargando mensajes no leídos</span>
-                </span>
-              ) : hasUnreadMessages ? (
-                <Badge className="absolute -top-1.5 -right-1.5 flex h-5 min-w-[1.25rem] items-center justify-center px-1.5 text-[10px] leading-none bg-red-500 text-white">
-                  {displayUnreadMessagesCount}
-                </Badge>
-              ) : null}
-            </Link>
-          </Button>
         </div>
       </div>
     </nav>

--- a/src/components/Dashboard/Reports.tsx
+++ b/src/components/Dashboard/Reports.tsx
@@ -147,21 +147,22 @@ const Reports: React.FC = () => {
   );
 
   return (
-    <div className="mt-2 space-y-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-4">
-          <div className="rounded-full bg-primary/10 p-3 text-primary">
-            <FileBarChart className="h-6 w-6" />
+    <div className="mt-2 space-y-8 pb-10">
+      <div className="flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-[0_22px_65px_-38px_rgba(15,23,42,0.45)] sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-4">
+          <div className="rounded-full bg-financial-mint/50 p-3 text-primary">
+            <FileBarChart className="h-5 w-5" />
           </div>
           <div>
-            <h1 className="text-3xl font-semibold tracking-tight">Mis informes</h1>
-            <p className="text-muted-foreground">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">Reportes y documentos</p>
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">Mis informes</h1>
+            <p className="text-sm text-muted-foreground">
               Consulta y descarga los reportes que tu asesora comparte contigo.
             </p>
           </div>
         </div>
         <Button
-          className="w-full sm:w-auto"
+          className="w-full rounded-full bg-primary px-6 py-2 text-primary-foreground shadow-[0_18px_45px_-30px_rgba(37,99,235,0.8)] transition hover:bg-primary/90 sm:w-auto"
           onClick={() => handleDownloadReport(latestReport)}
           disabled={!latestReport}
         >
@@ -169,15 +170,18 @@ const Reports: React.FC = () => {
         </Button>
       </div>
 
-      <Card>
+      <Card className="glass-card">
         <CardHeader>
-          <CardTitle>Historial de informes</CardTitle>
+          <CardTitle className="text-xl font-semibold">Historial de informes</CardTitle>
+          <CardDescription className="text-sm text-muted-foreground">
+            Filtra y accede a los documentos relevantes cuando lo necesites.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="flex justify-end md:hidden">
             <Dialog open={isFiltersDialogOpen} onOpenChange={setIsFiltersDialogOpen}>
               <DialogTrigger asChild>
-                <Button variant="outline" size="icon" aria-label="Abrir filtros">
+                <Button variant="outline" size="icon" aria-label="Abrir filtros" className="rounded-full border border-white/60 bg-white/80">
                   <Filter className="h-5 w-5" />
                   <span className="sr-only">Abrir filtros</span>
                 </Button>
@@ -219,7 +223,7 @@ const Reports: React.FC = () => {
           </div>
 
           {error && (
-            <Alert variant="destructive">
+            <Alert variant="destructive" className="border border-destructive/30 bg-white/80">
               <AlertTriangle className="h-4 w-4" />
               <AlertTitle>Error al cargar</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
@@ -227,10 +231,7 @@ const Reports: React.FC = () => {
           )}
 
           {isLoading ? (
-            <LoadingState
-              label="Cargando informes..."
-              className="justify-center py-10"
-            />
+            <LoadingState label="Cargando informes..." className="justify-center py-10" />
           ) : filteredReports.length ? (
             <Table>
               <TableHeader>
@@ -252,6 +253,7 @@ const Reports: React.FC = () => {
                         variant="outline"
                         size="sm"
                         onClick={() => handleDownloadReport(report)}
+                        className="rounded-full border border-white/60 bg-white/80"
                       >
                         <Download className="mr-2 h-4 w-4" /> Descargar
                       </Button>
@@ -261,16 +263,10 @@ const Reports: React.FC = () => {
               </TableBody>
             </Table>
           ) : (
-            <div className="rounded-lg border border-dashed border-border py-10 text-center">
-              <p className="text-sm text-muted-foreground">
-                No encontramos informes.
-              </p>
+            <div className="rounded-3xl border border-dashed border-white/60 bg-white/60 py-10 text-center">
+              <p className="text-sm text-muted-foreground">No encontramos informes.</p>
               <div className="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row">
-                <Button
-                  variant="outline"
-                  onClick={handleClearFilters}
-                  disabled={!canClearFilters}
-                >
+                <Button variant="outline" onClick={handleClearFilters} disabled={!canClearFilters}>
                   Limpiar filtros
                 </Button>
               </div>

--- a/src/components/Dashboard/Sidebar.tsx
+++ b/src/components/Dashboard/Sidebar.tsx
@@ -82,38 +82,44 @@ const Sidebar = () => {
       )}
 
       <aside
-        className={`fixed inset-y-0 left-0 z-40 w-64 bg-card text-foreground border-r border-border transform transition-transform duration-300 ease-in-out sm:translate-x-0 ${
+        className={`fixed inset-y-0 left-0 z-40 w-64 transform border-r border-white/40 bg-white/65 pb-6 pt-8 shadow-[0_25px_70px_-40px_rgba(30,64,175,0.65)] backdrop-blur-xl transition-transform duration-300 ease-in-out sm:translate-x-0 ${
           isMenuOpen ? "translate-x-0" : "-translate-x-full"
         }`}
         role={isMenuOpen ? "dialog" : undefined}
         aria-modal={isMenuOpen ? true : undefined}
         aria-label="Menú principal"
       >
-        <div className="flex h-full flex-col">
-          <div className="border-b border-border p-6">
-            <div className="rounded-lg bg-white/5 p-4">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <h3 className="text-sm font-medium">Bienvenido/a</h3>
-                  <p className="font-semibold text-foreground">
-                    {user?.nombre} {user?.apellido}
-                  </p>
-                </div>
-                <Button
-                  ref={closeButtonRef}
-                  type="button"
-                  variant="ghost"
-                  className="h-8 w-8 p-0 sm:hidden"
-                  onClick={() => setIsMenuOpen(false)}
-                >
-                  <X className="h-4 w-4" aria-hidden="true" />
-                  <span className="sr-only">Cerrar menú</span>
-                </Button>
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          <div className="absolute left-1/2 top-4 h-32 w-32 -translate-x-1/2 rounded-full bg-financial-blue/15 blur-2xl" />
+          <div className="absolute bottom-10 right-6 h-24 w-24 rounded-full bg-financial-mint/25 blur-2xl" />
+        </div>
+
+        <div className="flex h-full flex-col px-6">
+          <div className="relative mb-6 rounded-3xl border border-white/50 bg-white/70 p-5 shadow-[0_20px_60px_-40px_rgba(15,23,42,0.45)]">
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">Bienvenida</p>
+                <p className="text-lg font-semibold text-foreground">
+                  {user?.nombre} {user?.apellido}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Gestiona tus inversiones con tranquilidad.
+                </p>
               </div>
+              <Button
+                ref={closeButtonRef}
+                type="button"
+                variant="ghost"
+                className="h-8 w-8 rounded-full border border-transparent p-0 text-muted-foreground transition hover:border-border hover:text-foreground sm:hidden"
+                onClick={() => setIsMenuOpen(false)}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+                <span className="sr-only">Cerrar menú</span>
+              </Button>
             </div>
           </div>
 
-          <nav className="flex-1 overflow-y-auto p-6">
+          <nav className="relative z-10 flex-1 overflow-y-auto pb-6">
             <ul className="space-y-2">
               {navigation.map((item) => {
                 const isActive = location.pathname === item.href;
@@ -123,15 +129,23 @@ const Sidebar = () => {
                   <li key={item.name}>
                     <NavLink
                       to={item.href}
-                      className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-colors ${
+                      className={`group flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition ${
                         isActive
-                          ? "bg-primary text-primary-foreground shadow-sm"
-                          : "text-foreground/70 hover:text-foreground hover:bg-muted"
+                          ? "bg-gradient-to-r from-primary to-financial-blue text-primary-foreground shadow-[0_12px_40px_-26px_rgba(37,99,235,0.75)]"
+                          : "text-foreground/70 hover:text-foreground hover:shadow-[0_16px_40px_-28px_rgba(15,23,42,0.28)] hover:bg-white/75"
                       }`}
                       onClick={handleLinkClick}
                     >
-                      <Icon className="h-5 w-5" />
-                      <span className="font-medium">{item.name}</span>
+                      <span
+                        className={`flex h-9 w-9 items-center justify-center rounded-2xl border text-sm transition ${
+                          isActive
+                            ? "border-white/30 bg-white/20 text-primary-foreground"
+                            : "border-white/50 bg-white/80 text-primary"
+                        }`}
+                      >
+                        <Icon className="h-4 w-4" />
+                      </span>
+                      <span>{item.name}</span>
                       {item.name === "Chat" && (
                         isUnreadLoading ? (
                           <span className="ml-auto flex h-5 w-5 items-center justify-center" aria-live="polite">
@@ -139,7 +153,7 @@ const Sidebar = () => {
                             <span className="sr-only">Cargando mensajes no leídos</span>
                           </span>
                         ) : hasUnreadMessages ? (
-                          <Badge className="ml-auto flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-2 text-xs text-white">
+                          <Badge className="ml-auto rounded-full bg-financial-rose/80 px-2 text-[11px] font-semibold text-financial-navy">
                             {displayUnreadMessagesCount}
                           </Badge>
                         ) : null
@@ -151,17 +165,22 @@ const Sidebar = () => {
             </ul>
           </nav>
 
-          <div className="border-t border-border p-6">
-            <Button
-              onClick={() => {
-                void logout();
-              }}
-              variant="ghost"
-              className="w-full justify-start text-foreground/70 hover:text-foreground hover:bg-muted"
-            >
-              <LogOut className="mr-3 h-5 w-5" />
-              Cerrar sesión
-            </Button>
+          <div className="relative z-10 mt-auto">
+            <div className="rounded-3xl border border-white/50 bg-white/70 p-4 shadow-[0_14px_45px_-30px_rgba(15,23,42,0.45)]">
+              <p className="mb-3 text-xs text-muted-foreground">
+                ¿Necesitas salir?
+              </p>
+              <Button
+                onClick={() => {
+                  void logout();
+                }}
+                variant="ghost"
+                className="w-full justify-center rounded-full border border-transparent bg-white/80 text-sm font-medium text-foreground transition hover:border-destructive/30 hover:bg-white"
+              >
+                <LogOut className="mr-2 h-4 w-4" />
+                Cerrar sesión
+              </Button>
+            </div>
           </div>
         </div>
       </aside>

--- a/src/index.css
+++ b/src/index.css
@@ -8,52 +8,59 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-  --background: 248 250% 99%;
-  --foreground: 221 43% 10%;
+    --background: 220 46% 97%;
+    --foreground: 221 43% 14%;
 
-  --card: 0 0% 100%;
-  --card-foreground: 221 43% 12%;
+    --card: 0 0% 100%;
+    --card-foreground: 221 43% 14%;
 
-  --popover: 0 0% 100%;
-  --popover-foreground: 221 39% 8%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 221 43% 12%;
 
-  --primary: 221 83% 53%;
-  --primary-foreground: 0 0% 98%;
-  --primary-hover: 221 83% 48%;
+    --primary: 221 83% 54%;
+    --primary-foreground: 0 0% 98%;
+    --primary-hover: 221 83% 48%;
 
-  --secondary: 210 40% 96%;
-  --secondary-foreground: 221 39% 8%;
+    --secondary: 218 34% 94%;
+    --secondary-foreground: 221 39% 20%;
 
-  --muted: 220 14% 96%;
-  --muted-foreground: 221 16% 32%;
+    --muted: 220 20% 94%;
+    --muted-foreground: 221 19% 35%;
 
-  --accent: 142 76% 36%;
-  --accent-foreground: 0 0% 98%;
+    --accent: 158 62% 48%;
+    --accent-foreground: 0 0% 98%;
 
-  --success: 142 76% 36%;
-  --success-foreground: 0 0% 98%;
+    --success: 157 66% 40%;
+    --success-foreground: 0 0% 98%;
 
-  --warning: 38 92% 50%;
-  --warning-foreground: 0 0% 98%;
+    --warning: 36 92% 55%;
+    --warning-foreground: 0 0% 10%;
 
-  --destructive: 0 84% 60%;
-  --destructive-foreground: 0 0% 98%;
+    --destructive: 350 84% 56%;
+    --destructive-foreground: 0 0% 98%;
 
-  --border:  220 13% 88%;
-  --input: 220 13% 91%;
-  --ring: 221 83% 53%;
+    --border: 220 18% 86%;
+    --input: 220 18% 90%;
+    --ring: 221 83% 53%;
 
-  --radius: 0.5rem;
+    --radius: 0.75rem;
 
---sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 6% 18%;
-    --sidebar-primary: 240 6% 10%;
+    --sidebar-background: 0 0% 100%;
+    --sidebar-foreground: 222 47% 20%;
+    --sidebar-primary: 221 83% 54%;
     --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 240 5% 96%;
-    --sidebar-accent-foreground: 240 6% 14%;
-    --sidebar-border: 220 13% 88%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-}
+    --sidebar-accent: 220 38% 96%;
+    --sidebar-accent-foreground: 222 47% 20%;
+    --sidebar-border: 220 18% 86%;
+    --sidebar-ring: 221 83% 53%;
+
+    --financial-blue: 221 83% 53%;
+    --financial-navy: 224 68% 26%;
+    --financial-sky: 205 92% 95%;
+    --financial-mint: 158 52% 88%;
+    --financial-sand: 35 100% 92%;
+    --financial-rose: 345 70% 90%;
+  }
 
   .dark {
     --background: 222.2 84% 4.9%; /* Fondo oscuro */
@@ -101,6 +108,22 @@ All colors MUST be HSL.
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
+    background-image:
+      radial-gradient(circle at 0% 0%, hsl(var(--financial-sky) / 0.9), transparent 55%),
+      radial-gradient(circle at 100% 10%, hsl(var(--financial-mint) / 0.7), transparent 55%),
+      radial-gradient(circle at 50% 100%, hsl(var(--financial-rose) / 0.4), transparent 60%),
+      linear-gradient(180deg, hsl(var(--background)) 0%, hsl(var(--background)) 40%, #fff 100%);
+    background-attachment: fixed;
+  }
+}
+
+@layer components {
+  .glass-card {
+    @apply rounded-3xl border border-white/60 bg-white/70 shadow-[0_28px_80px_-36px_rgba(30,64,175,0.45)] backdrop-blur-xl;
+  }
+
+  .soft-card {
+    @apply rounded-3xl border border-white/40 bg-white/60 shadow-[0_16px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur-xl;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,17 +19,25 @@ export default {
 			}
 		},
 		extend: {
-			colors: {
-				border: 'hsl(var(--border))',
-				input: 'hsl(var(--input))',
-				ring: 'hsl(var(--ring))',
-				background: 'hsl(var(--background))',
-				foreground: 'hsl(var(--foreground))',
-				primary: {
-					DEFAULT: 'hsl(var(--primary))',
-					foreground: 'hsl(var(--primary-foreground))',
-					hover: 'hsl(var(--primary-hover))'
-				},
+                        colors: {
+                                border: 'hsl(var(--border))',
+                                input: 'hsl(var(--input))',
+                                ring: 'hsl(var(--ring))',
+                                background: 'hsl(var(--background))',
+                                foreground: 'hsl(var(--foreground))',
+                                financial: {
+                                        blue: 'hsl(var(--financial-blue))',
+                                        navy: 'hsl(var(--financial-navy))',
+                                        sky: 'hsl(var(--financial-sky))',
+                                        mint: 'hsl(var(--financial-mint))',
+                                        sand: 'hsl(var(--financial-sand))',
+                                        rose: 'hsl(var(--financial-rose))'
+                                },
+                                primary: {
+                                        DEFAULT: 'hsl(var(--primary))',
+                                        foreground: 'hsl(var(--primary-foreground))',
+                                        hover: 'hsl(var(--primary-hover))'
+                                },
 				secondary: {
 					DEFAULT: 'hsl(var(--secondary))',
 					foreground: 'hsl(var(--secondary-foreground))'


### PR DESCRIPTION
## Summary
- update design tokens and introduce reusable glass surface utilities for a softer visual language
- redesign the dashboard shell with gradient background, glass navigation, and refreshed sidebar layout
- modernize dashboard home, messaging, and reports views with welcoming hero content, guided actions, and refined cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e68dbb3ae083308580e51af7c115b7